### PR TITLE
Ignore empty lines and lines starting with #

### DIFF
--- a/bookmenu
+++ b/bookmenu
@@ -159,7 +159,7 @@ Website() {
 }
 
 SelectBookmark() {
-  Bookmark=$(sort "$BookmarksFile" | sed "s/$Seperator.*//" | SelectFinder \
+  Bookmark=$(sort "$BookmarksFile" | grep -v '^#\|^\s*$' sed "s/$Seperator.*//" | SelectFinder \
     | SelectPath)
   if [ -z "$Bookmark" ]; then
     Err 1 "No bookmark selected"

--- a/bookmenu
+++ b/bookmenu
@@ -159,7 +159,7 @@ Website() {
 }
 
 SelectBookmark() {
-  Bookmark=$(sort "$BookmarksFile" | grep -v '^#\|^\s*$' sed "s/$Seperator.*//" | SelectFinder \
+  Bookmark=$(sort "$BookmarksFile" | grep -v '^#\|^\s*$' | sed "s/$Seperator.*//" | SelectFinder \
     | SelectPath)
   if [ -z "$Bookmark" ]; then
     Err 1 "No bookmark selected"


### PR DESCRIPTION
For better readability of the bookmarks file, user can add empty lines (or lines with only spaces/tabs) and can add comments using # at the beginning of the line.